### PR TITLE
chore: [IOPID-1714] Handle malformed response

### DIFF
--- a/ciesdk/iociesdkios/CIEIDSdk.swift
+++ b/ciesdk/iociesdkios/CIEIDSdk.swift
@@ -237,36 +237,36 @@ public class CIEIDSdk : NSObject, NFCTagReaderSessionDelegate {
             {
                 case 0:  // OK
                 session?.alertMessage = self.alertMessages[AlertMessageKey.readingSuccess]!
-                let response = String(data: data ?? missingDataPlaceholder, encoding: .utf8)
-                do {
-                  guard let response = response else {
-                      throw NSError(
-                        domain: "ios-cie-sdk",
-                        code: 100,
-                        userInfo: [NSLocalizedDescriptionKey: "Response is nil."]
-                      )
-                  }
-                  let components = response.split(separator: ":")
-                  if components.count < 2 {
-                      throw NSError(
-                        domain: "ios-cie-sdk",
-                        code: 101,
-                        userInfo: [
-                          NSLocalizedDescriptionKey:
-                            "Expected component not found after splitting response."
-                        ]
-                      )
-                  }
-                  let serverCode = String(components[1])
-                  let newurl = nextUrl + "?" + name + "=" + value + "&login=1&codice=" + serverCode
-                  self.debugPrint("newurl \(newurl)")
-                  self.completedHandler(nil, newurl)
-                  session?.invalidate()
-                } catch {
-                  self.debugPrint("An error occurred: \(error.localizedDescription)")
-                  self.completedHandler("AUTHENTICATION_ERROR", nil)
-                  session?.invalidate(errorMessage: self.alertMessages[AlertMessageKey.genericError]!)
-                }
+                    let response = String(data: data ?? missingDataPlaceholder, encoding: .utf8)
+                    do {
+                      guard let response = response else {
+                          throw NSError(
+                            domain: "ios-cie-sdk",
+                            code: 100,
+                            userInfo: [NSLocalizedDescriptionKey: "Response is nil."]
+                          )
+                      }
+                      let components = response.split(separator: ":")
+                      if components.count < 2 {
+                          throw NSError(
+                            domain: "ios-cie-sdk",
+                            code: 101,
+                            userInfo: [
+                              NSLocalizedDescriptionKey:
+                                "Expected component not found after splitting response."
+                            ]
+                          )
+                      }
+                      let serverCode = String(components[1])
+                      let newurl = nextUrl + "?" + name + "=" + value + "&login=1&codice=" + serverCode
+                      self.debugPrint("newurl \(newurl)")
+                      self.completedHandler(nil, newurl)
+                      session?.invalidate()
+                    } catch {
+                      self.debugPrint("An error occurred: \(error.localizedDescription)")
+                      self.completedHandler("AUTHENTICATION_ERROR", nil)
+                      session?.invalidate(errorMessage: self.alertMessages[AlertMessageKey.genericError]!)
+                    }
                     break;
                 case 0x63C0,0x6983: // PIN LOCKED
                     self.attemptsLeft = 0

--- a/ciesdk/iociesdkios/CIEIDSdk.swift
+++ b/ciesdk/iociesdkios/CIEIDSdk.swift
@@ -235,12 +235,36 @@ public class CIEIDSdk : NSObject, NFCTagReaderSessionDelegate {
             {
                 case 0:  // OK
                 session?.alertMessage = self.alertMessages[AlertMessageKey.readingSuccess]!
-                    let response = String(data: data ?? missingDataPlaceholder, encoding: .utf8)
-                    let serverCode = String((response?.split(separator: ":")[1] ?? ""))
-                    let newurl = nextUrl + "?" + name + "=" + value + "&login=1&codice=" + serverCode
-                    self.debugPrint("newurl \(newurl)")
-                    self.completedHandler(nil, newurl)
-                    session?.invalidate()
+                let response = String(data: data ?? missingDataPlaceholder, encoding: .utf8)
+                do {
+                  guard let response = response else {
+                      throw NSError(
+                        domain: "ios-cie-sdk",
+                        code: 100,
+                        userInfo: [NSLocalizedDescriptionKey: "Response is nil."]
+                      )
+                  }
+                  let components = response.split(separator: ":")
+                  if components.count < 2 {
+                      throw NSError(
+                        domain: "ios-cie-sdk",
+                        code: 101,
+                        userInfo: [
+                          NSLocalizedDescriptionKey:
+                            "Expected component not found after splitting response."
+                        ]
+                      )
+                  }
+                  let serverCode = String(components[1])
+                  let newurl = nextUrl + "?" + name + "=" + value + "&login=1&codice=" + serverCode
+                  self.debugPrint("newurl \(newurl)")
+                  self.completedHandler(nil, newurl)
+                  session?.invalidate()
+                } catch {
+                  self.debugPrint("An error occurred: \(error.localizedDescription)")
+                  self.completedHandler("AUTHENTICATION_ERROR", nil)
+                  session?.invalidate()
+                }
                     break;
                 case 0x63C0,0x6983: // PIN LOCKED
                     self.attemptsLeft = 0

--- a/ciesdk/iociesdkios/CIEIDSdk.swift
+++ b/ciesdk/iociesdkios/CIEIDSdk.swift
@@ -47,6 +47,7 @@ enum AlertMessageKey : String {
     case cardLocked
     case wrongPin1AttemptLeft
     case wrongPin2AttemptLeft
+    case genericError
 }
 
 
@@ -95,6 +96,7 @@ public class CIEIDSdk : NSObject, NFCTagReaderSessionDelegate {
         alertMessages[AlertMessageKey.cardLocked] = "Carta CIE bloccata"
         alertMessages[AlertMessageKey.wrongPin1AttemptLeft] = "PIN errato, hai ancora 1 tentativo"
         alertMessages[AlertMessageKey.wrongPin2AttemptLeft] = "PIN errato, hai ancora 2 tentativi"
+        alertMessages[AlertMessageKey.genericError] = "Qualcosa è andato storto"
     }
     
     @objc
@@ -263,7 +265,7 @@ public class CIEIDSdk : NSObject, NFCTagReaderSessionDelegate {
                 } catch {
                   self.debugPrint("An error occurred: \(error.localizedDescription)")
                   self.completedHandler("AUTHENTICATION_ERROR", nil)
-                  session?.invalidate()
+                  session?.invalidate(errorMessage: self.alertMessages[AlertMessageKey.genericError]!)
                 }
                     break;
                 case 0x63C0,0x6983: // PIN LOCKED


### PR DESCRIPTION
This PR handle malformed responses to avoid crashes in those use cases.

## List of changes
- In case of EIC reading success if we are not able to parse the response, we do not crash and: 
  - we return an `AUTHENTICATION_ERROR` .
  - we set a generic error message with default value: `alertMessages[AlertMessageKey.genericError] = "Qualcosa è andato storto"`.
 